### PR TITLE
Content-Type: text/x-vcard; charset=utf-8

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -62,6 +62,7 @@ class DefaultController extends Controller
     $options = VCard::$plugin->service->decodeUrlParam( $vcard );
 
     VCard::$plugin->service->generateVcard( $options );
+    Craft::$app->response->format = \yii\web\Response::FORMAT_RAW;
 
     Craft::$app->end();
   }


### PR DESCRIPTION
Content-Type header is being overridden by the HTML response formatter.
Propose resetting the response headers to ensure content-type is properly set to `text/x-vcard; charset=utf-8`